### PR TITLE
EDX-270: Redirect disabled account to disabled_account.html

### DIFF
--- a/common/djangoapps/student/middleware.py
+++ b/common/djangoapps/student/middleware.py
@@ -5,7 +5,9 @@ disabled accounts from accessing the site.
 from django.http import HttpResponseForbidden
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from edxmako.shortcuts import render_to_response
 from student.models import UserStanding
+import student.views
 
 class UserStandingMiddleware(object):
     """
@@ -34,4 +36,7 @@ class UserStandingMiddleware(object):
                             ),
                             link_end=u'</a>'
                         )
-                return HttpResponseForbidden(msg)
+                # logout
+                student.views.logout_user(request)
+                context = {'message': msg}
+                return render_to_response('disabled_account.html', context)

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -74,9 +74,10 @@ class UserStandingTest(TestCase):
             UserStanding.ACCOUNT_DISABLED
         )
 
-    def test_disabled_account_403s(self):
+    def test_disabled_account_redirect_to_disabled_account_page(self):
         response = self.bad_user_client.get(self.some_url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("Disabled Account" in response.content)
 
     def test_reenable_account(self):
         try:

--- a/lms/templates/disabled_account.html
+++ b/lms/templates/disabled_account.html
@@ -1,0 +1,9 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="main.html" />
+
+<%block name="pagetitle">${_("Disabled Account")}</%block>
+
+<section class="outside-app">
+  <h1>${_("Disabled Account")}</h1>
+  <p>${message}</p>
+</section>


### PR DESCRIPTION
Add a feature for account withdrawal.
If a user whose account is already disabled accesses to a gacco's page, the user will be redirected to disabled_account.html.
